### PR TITLE
refactor(): rename addSerie to addSeries

### DIFF
--- a/src/chart.ts
+++ b/src/chart.ts
@@ -70,7 +70,7 @@ export class Chart {
    * @param animation     Whether to apply animation, and optionally animation configuration. This defaults to false.
    * @memberof Chart
    */
-  public addSerie(
+  public addSeries(
     serie: Highcharts.SeriesOptions,
     redraw = true,
     animation: boolean | Highcharts.Animation = false


### PR DESCRIPTION
This method should be renamed because of spelling.