### PR TITLE
no-angle-bracket-type-assertion problem fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,7 +293,7 @@ If you expiring typing errors while you build/serve your angular app the followi
 
 ```ts
 // override options type with <any>
-chart = new Chart(<any>{ options });
+chart = new Chart({ options } as any);
 ```
 This is very useful when using `gauge chart` type.
 ## Demo


### PR DESCRIPTION
With previous version *tslint* generates following error:

> Type assertion using the '<>' syntax is forbidden. Use the 'as' syntax instead.

which is fixed by using `as any`