### PR TITLE
#351 apply modules to highcharts, highstock, highmaps

### DIFF
--- a/projects/angular-highcharts/src/lib/chart.service.ts
+++ b/projects/angular-highcharts/src/lib/chart.service.ts
@@ -8,6 +8,8 @@
  */
 import { Inject, Injectable, InjectionToken } from '@angular/core';
 import * as Highcharts from 'highcharts';
+import * as Highstock from 'highcharts/highstock';
+import * as Highmaps from 'highcharts/highmaps';
 
 export let HIGHCHARTS_MODULES = new InjectionToken<any[]>('HighchartsModules');
 
@@ -17,7 +19,7 @@ export class ChartService {
 
   initModules() {
     this.chartModules.forEach(chartModule => {
-      chartModule(Highcharts);
+      [Highcharts, Highstock, Highmaps].forEach(chartModule);
     });
   }
 }

--- a/projects/angular-highcharts/src/lib/chart.service.ts
+++ b/projects/angular-highcharts/src/lib/chart.service.ts
@@ -10,6 +10,7 @@ import { Inject, Injectable, InjectionToken } from '@angular/core';
 import * as Highcharts from 'highcharts';
 import * as Highstock from 'highcharts/highstock';
 import * as Highmaps from 'highcharts/highmaps';
+import * as Highcharts_Gnatt from 'highcharts/highcharts-gantt';
 
 export let HIGHCHARTS_MODULES = new InjectionToken<any[]>('HighchartsModules');
 
@@ -19,7 +20,7 @@ export class ChartService {
 
   initModules() {
     this.chartModules.forEach(chartModule => {
-      [Highcharts, Highstock, Highmaps].forEach(chartModule);
+      [Highcharts, Highstock, Highmaps, Highcharts_Gnatt].forEach(chartModule);
     });
   }
 }


### PR DESCRIPTION
Modules are not applied to anything except `Highcharts`, so they should be added to `highcharts/highstock` and `highcharts/highmaps` as well.
It is better to split related modules into something like 'ChartModule', 'StockChartModule', 'MapChartModule', but it will break backward compatibility.