### PR TITLE
Add highcharts peer dependency

### DIFF
--- a/projects/angular-highcharts/package.json
+++ b/projects/angular-highcharts/package.json
@@ -16,7 +16,8 @@
   "license": "MIT",
   "peerDependencies": {
     "@angular/common": "^15.1.1",
-    "@angular/core": "^15.1.1"
+    "@angular/core": "^15.1.1",
+    "highcharts": "^10.3.3"
   },
   "dependencies": {
     "tslib": "^2.3.0"


### PR DESCRIPTION
Since angular-highcharts works with this version range of highcharts, which
the user would themselves need access to.

Solves issue #389